### PR TITLE
Add Qwen3.5 auto-detection with recommended sampling defaults

### DIFF
--- a/src/llm_provider/providers/openai_api.py
+++ b/src/llm_provider/providers/openai_api.py
@@ -31,6 +31,29 @@ def model_id(model: str) -> str:
 _REASONING_PREFIXES = ("o1", "o3", "o4")
 _MAX_COMPLETION_PREFIXES = ("gpt-5", "o1", "o3", "o4")
 
+# Qwen3.5 recommended sampling parameters (model thinks by default)
+# Thinking general:           temperature=1.0, top_p=0.95, top_k=20, min_p=0.0, presence_penalty=1.5  [DEFAULT]
+# Thinking coding (WebDev):   temperature=0.6, top_p=0.95, top_k=20, min_p=0.0, presence_penalty=0.0
+# Instruct (non-thinking) general:  temperature=0.7, top_p=0.8,  top_k=20, min_p=0.0, presence_penalty=1.5
+# Instruct (non-thinking) reasoning: temperature=1.0, top_p=0.95, top_k=20, min_p=0.0, presence_penalty=1.5
+# All modes: repetition_penalty=1.0, max_tokens=32768 (81920 for hard math/code)
+# <think>...</think> stripping already handled by strip_thinking()
+_QWEN35_DEFAULTS = {
+    "temperature": 1.0,
+    "top_p": 0.95,
+    "presence_penalty": 1.5,
+    "max_tokens": 32768,
+}
+_QWEN35_EXTRA_DEFAULTS = {
+    "top_k": 20,
+    "min_p": 0.0,
+    "repetition_penalty": 1.0,
+}
+
+
+def _is_qwen35(mid: str) -> bool:
+    return "qwen3.5" in mid.lower()
+
 
 def _prepare_kwargs(mid: str, kwargs: dict) -> tuple[dict, bool]:
     """Normalize kwargs for reasoning model compatibility. Returns (kwargs, use_cache)."""
@@ -47,6 +70,17 @@ def _prepare_kwargs(mid: str, kwargs: dict) -> tuple[dict, bool]:
     # Reasoning models reject temperature
     if any(mid.startswith(p) for p in _REASONING_PREFIXES):
         kwargs.pop("temperature", None)
+
+    # Qwen3.5: inject recommended defaults (user-provided values take precedence)
+    if _is_qwen35(mid):
+        for k, v in _QWEN35_DEFAULTS.items():
+            kwargs.setdefault(k, v)
+        extra = kwargs.get("extra_body") or {}
+        for k, v in _QWEN35_EXTRA_DEFAULTS.items():
+            if k not in kwargs and k not in extra:
+                extra[k] = v
+        if extra:
+            kwargs["extra_body"] = extra
 
     return kwargs, use_cache
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -342,6 +342,48 @@ class TestStripThinking:
         assert openai_api.strip_thinking(raw) == ""
 
 
+class TestPrepareKwargs:
+    """Test _prepare_kwargs handles model-specific defaults."""
+
+    def test_qwen35_injects_defaults(self):
+        """Qwen3.5 models get recommended sampling defaults."""
+        kwargs, _ = openai_api._prepare_kwargs("Qwen/Qwen3.5-27B", {})
+        assert kwargs["temperature"] == 1.0
+        assert kwargs["top_p"] == 0.95
+        assert kwargs["presence_penalty"] == 1.5
+        assert kwargs["max_tokens"] == 32768
+        assert kwargs["extra_body"]["top_k"] == 20
+        assert kwargs["extra_body"]["min_p"] == 0.0
+        assert kwargs["extra_body"]["repetition_penalty"] == 1.0
+
+    def test_qwen35_user_overrides(self):
+        """User-provided values take precedence over Qwen3.5 defaults."""
+        kwargs, _ = openai_api._prepare_kwargs(
+            "Qwen/Qwen3.5-27B", {"temperature": 0.6, "extra_body": {"top_k": 50}}
+        )
+        assert kwargs["temperature"] == 0.6
+        assert kwargs["extra_body"]["top_k"] == 50
+        # Non-overridden defaults still applied
+        assert kwargs["top_p"] == 0.95
+        assert kwargs["extra_body"]["min_p"] == 0.0
+
+    def test_qwen35_case_insensitive(self):
+        """Detection works regardless of casing in model path."""
+        kwargs, _ = openai_api._prepare_kwargs("qwen/qwen3.5-35b-a3b", {})
+        assert kwargs["temperature"] == 1.0
+
+    def test_non_qwen35_untouched(self):
+        """Non-Qwen3.5 models don't get defaults injected."""
+        kwargs, _ = openai_api._prepare_kwargs("Qwen/Qwen3-4B", {})
+        assert "temperature" not in kwargs
+        assert "extra_body" not in kwargs
+
+    def test_reasoning_model_strips_temperature(self):
+        """Reasoning models still strip temperature."""
+        kwargs, _ = openai_api._prepare_kwargs("o3-mini", {"temperature": 0.5})
+        assert "temperature" not in kwargs
+
+
 class TestCallThinkingIntegration:
     """Test that openai_api.call() correctly handles thinking in responses."""
 


### PR DESCRIPTION
## Summary
- Auto-detect Qwen3.5 models (case-insensitive) in `_prepare_kwargs` and inject official recommended sampling defaults
- Default to "thinking general" config: `temperature=1.0, top_p=0.95, top_k=20, min_p=0.0, presence_penalty=1.5, max_tokens=32768`
- User-provided values always take precedence over defaults

## Test plan
- [x] 5 new unit tests covering defaults injection, user overrides, case sensitivity, non-Qwen3.5 passthrough
- [x] Full suite: 94 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)