### PR TITLE
Add opt-in per-call usage logging

### DIFF
--- a/src/llm_provider/provider.py
+++ b/src/llm_provider/provider.py
@@ -408,6 +408,12 @@ class LLM:
         self.total_output_tokens += usage.get("output_tokens", 0)
         self.total_cached_tokens += usage.get("cached_tokens", 0)
         self.total_cost += usage.get("cost", 0.0)
+
+        if hasattr(self, "_usage_log") and isinstance(self._usage_log, dict):
+            self._usage_log[prompt] = {
+                k: usage.get(k, 0) for k in ("input_tokens", "output_tokens")
+            }
+
         return texts
 
     # --- chat() — sync, messages-based ---

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -602,6 +602,41 @@ class TestLLMGenerate:
         assert k1 != k2
 
 
+# --- Per-call usage logging ---
+
+
+class TestUsageLog:
+    def test_usage_log_opt_in(self):
+        """When _usage_log is set, per-call usage is recorded keyed by prompt."""
+        llm = LLM("anthropic/claude-sonnet-4-6")
+        llm._usage_log = {}
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Hello!"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.prompt_tokens_details = None
+
+        with patch("llm_provider.providers.litellm_api._litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(
+                return_value=mock_response
+            )
+            mock_litellm.return_value.completion_cost.return_value = 0.0
+
+            llm.generate("What is 2+2?", silent=True)
+
+        assert "What is 2+2?" in llm._usage_log
+        assert llm._usage_log["What is 2+2?"]["input_tokens"] == 10
+        assert llm._usage_log["What is 2+2?"]["output_tokens"] == 5
+
+    def test_no_usage_log_by_default(self):
+        """Without _usage_log, no per-call tracking (backwards-compatible)."""
+        llm = LLM("anthropic/claude-sonnet-4-6")
+        assert not hasattr(llm, "_usage_log")
+
+
 # --- Retry on 429 ---
 
 


### PR DESCRIPTION
Fixes #1

## Summary
- Add 3 lines to `_call()`: when `_usage_log` dict exists on the instance, store per-call `{input_tokens, output_tokens}` keyed by prompt text
- Fully backwards-compatible: no behavior change unless `llm._usage_log = {}` is explicitly set
- Safe with asyncio.gather (single-threaded, no races)

## Usage
```python
llm = LLM("local/openai/gpt-oss-120b")
llm._usage_log = {}  # opt-in
results = llm.generate(prompts)
# llm._usage_log["prompt text"] -> {"input_tokens": ..., "output_tokens": ...}
```

## Test plan
- [x] Test opt-in logging records correct per-prompt usage
- [x] Test no `_usage_log` attribute by default (backwards-compatible)
- [x] Full suite: 91 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)