### PR TITLE
Fix CLOSE_WAIT connection leaks in LLM

### DIFF
--- a/src/llm_provider/provider.py
+++ b/src/llm_provider/provider.py
@@ -291,6 +291,61 @@ class LLM:
                     on_headers=self._sem.on_headers if self._provider.http2 else None,
                 )
 
+    def close(self):
+        """Close underlying HTTP clients to prevent connection leaks."""
+        from llm_provider.providers._pool import ClientPool
+
+        # Close async client(s)
+        client = getattr(self, "_client", None)
+        if client is not None:
+            if isinstance(client, ClientPool):
+                try:
+                    asyncio.run(client.aclose_all())
+                except RuntimeError:
+                    client.close_all()
+            elif hasattr(client, "close"):
+                try:
+                    result = client.close()
+                    if asyncio.iscoroutine(result):
+                        try:
+                            asyncio.run(result)
+                        except RuntimeError:
+                            pass
+                except Exception:
+                    pass
+
+        # Close sync client(s)
+        if self._sync_client is not None:
+            if isinstance(self._sync_client, ClientPool):
+                self._sync_client.close_all()
+            elif hasattr(self._sync_client, "close"):
+                try:
+                    self._sync_client.close()
+                except Exception:
+                    pass
+            self._sync_client = None
+
+        # Close anthropic client
+        anthropic_client = getattr(self, "_anthropic_client", None)
+        if anthropic_client is not None:
+            try:
+                anthropic_client.close()
+            except Exception:
+                pass
+            self._anthropic_client = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
     def generate(
         self,
         prompts: str | list[str],
@@ -710,11 +765,11 @@ def multi_generate(
     silent = kwargs.pop("silent", False)
 
     def _run(model: str):
-        llm = LLM(model)
-        result = llm.generate(
-            prompts, system_prompt=system_prompt, silent=True, **kwargs
-        )
-        return model, result, llm
+        with LLM(model) as llm:
+            result = llm.generate(
+                prompts, system_prompt=system_prompt, silent=True, **kwargs
+            )
+            return model, result, llm.total_cost
 
     results = {}
     total_cost = 0.0
@@ -723,9 +778,9 @@ def multi_generate(
     with ThreadPoolExecutor(max_workers=len(models)) as pool:
         futures = {pool.submit(_run, m): m for m in models}
         for future in as_completed(futures):
-            model, result, llm = future.result()
+            model, result, cost = future.result()
             results[model] = result
-            total_cost += llm.total_cost
+            total_cost += cost
 
     if not silent:
         elapsed = time.monotonic() - t0
@@ -754,9 +809,9 @@ def multi_chat(
     silent = kwargs.pop("silent", False)
 
     def _run(model: str):
-        llm = LLM(model)
-        result = llm.chat(messages, silent=True, **kwargs)
-        return model, result, llm
+        with LLM(model) as llm:
+            result = llm.chat(messages, silent=True, **kwargs)
+            return model, result, llm.total_cost
 
     results = {}
     total_cost = 0.0
@@ -765,9 +820,9 @@ def multi_chat(
     with ThreadPoolExecutor(max_workers=len(models)) as pool:
         futures = {pool.submit(_run, m): m for m in models}
         for future in as_completed(futures):
-            model, result, llm = future.result()
+            model, result, cost = future.result()
             results[model] = result
-            total_cost += llm.total_cost
+            total_cost += cost
 
     if not silent:
         elapsed = time.monotonic() - t0

--- a/src/llm_provider/providers/_pool.py
+++ b/src/llm_provider/providers/_pool.py
@@ -40,6 +40,28 @@ class ClientPool:
     def __len__(self):
         return len(self._clients)
 
+    def close_all(self):
+        """Close all clients in the pool."""
+        for client in self._clients:
+            if hasattr(client, "close"):
+                try:
+                    client.close()
+                except TypeError:
+                    pass  # async close — caller handles via aclose_all()
+                except Exception:
+                    pass
+
+    async def aclose_all(self):
+        """Close all async clients in the pool."""
+        for client in self._clients:
+            if hasattr(client, "close"):
+                try:
+                    result = client.close()
+                    if hasattr(result, "__await__"):
+                        await result
+                except Exception:
+                    pass
+
     # Allow pool to be used directly as the client (single-key case)
     def __getattr__(self, name):
         return getattr(self.current, name)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1257,3 +1257,61 @@ class TestMultiChat:
         for v in results.values():
             assert isinstance(v, str)
             assert v == "response"
+
+
+# --- Resource cleanup ---
+
+
+class TestLLMClose:
+    def test_close_litellm_no_client(self):
+        """close() on litellm model (no _client) should not raise."""
+        llm = LLM("anthropic/claude-sonnet-4-6")
+        llm.close()  # should be a no-op
+
+    def test_close_openai_client(self):
+        """close() should close the underlying AsyncOpenAI client."""
+        llm = LLM("gpt-4.1-nano")
+        assert hasattr(llm, "_client")
+        llm.close()
+        # Calling close again should be safe
+        llm.close()
+
+    def test_context_manager(self):
+        """LLM should work as a context manager."""
+        with LLM("anthropic/claude-sonnet-4-6") as llm:
+            assert llm.model == "anthropic/claude-sonnet-4-6"
+
+    def test_context_manager_closes_client(self):
+        """Exiting context manager should close the client."""
+        with LLM("gpt-4.1-nano") as llm:
+            assert hasattr(llm, "_client")
+        # sync_client should be None after close
+        assert llm._sync_client is None
+
+    def test_close_with_sync_client(self):
+        """close() should close lazily-created sync client."""
+        llm = LLM("gpt-4.1-nano")
+        sync = llm._get_sync_client()
+        assert sync is not None
+        llm.close()
+        assert llm._sync_client is None
+
+    def test_close_client_pool(self):
+        """close() should close all clients in a ClientPool."""
+        from llm_provider.providers._pool import ClientPool
+
+        mock_clients = [MagicMock() for _ in range(3)]
+        pool = ClientPool(mock_clients)
+        pool.close_all()
+        for c in mock_clients:
+            c.close.assert_called_once()
+
+    def test_aclose_client_pool(self):
+        """aclose_all() should await async close on all clients."""
+        from llm_provider.providers._pool import ClientPool
+
+        mock_clients = [AsyncMock() for _ in range(2)]
+        pool = ClientPool(mock_clients)
+        asyncio.run(pool.aclose_all())
+        for c in mock_clients:
+            c.close.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #4.

- Add `close()`, `__del__`, `__enter__`/`__exit__` to `LLM` so HTTP clients get cleaned up
- Add `close_all()`/`aclose_all()` to `ClientPool` to close all clients (not just `current`)
- Use `with LLM(...)` in `multi_generate`/`multi_chat` to auto-cleanup
- 7 new tests for resource cleanup

Usage:
```python
with LLM(model="local/Qwen/Qwen3.5-27B") as llm:
    results = llm.generate(prompts)
# connections cleaned up automatically
```

## Test plan

- [x] All 103 tests pass (96 existing + 7 new)
- [ ] Manual verification with long-running benchmark script

🤖 Generated with [Claude Code](https://claude.com/claude-code)